### PR TITLE
feat: ✨ add blistering scales tracking on tanks for augmentation

### DIFF
--- a/Buffs.lua
+++ b/Buffs.lua
@@ -129,6 +129,16 @@ BR.BUFF_TABLES = {
             missingText = "NO\nSOURCE",
         },
         {
+            spellID = 360827,
+            key = "blisteringScales",
+            name = "Blistering Scales",
+            class = "EVOKER",
+            beneficiaryRole = "TANK",
+            missingText = "NO\nSCALES",
+            requireSpecId = 1473, -- Augmentation
+            requiresTalentSpellID = 360827,
+        },
+        {
             spellID = 474750,
             key = "symbioticRelationship",
             name = "Symbiotic Relationship",


### PR DESCRIPTION
Adds missing Blistering Scales buff tracking.

It is setup to only run on as:
- evoker
- augmentation
- blistering scales talented

Will trigger if a tank does not have your buff same way source of magic checks against healers.